### PR TITLE
Improved touchscreen menu control

### DIFF
--- a/MMM-OnScreenMenu.css
+++ b/MMM-OnScreenMenu.css
@@ -99,7 +99,6 @@
     opacity: 0.8;
 }
 
-.osmContainer:hover .osmButtons.menu,
 .openMenu .osmButtons.menu {
     opacity: 0.8;
     -webkit-transition-delay: 0ms;
@@ -127,8 +126,7 @@
     transition-delay: 0ms;
 }
 
-.openMenu .osmButtons.menu .closed,
-.osmContainer:hover .osmButtons.menu .closed {
+.openMenu .osmButtons.menu .closed {
     opacity: 0 !important;
     -webkit-transition: all .1s ease-out;
     transition: all .1s ease-out;
@@ -136,7 +134,6 @@
     transition-delay: 500ms;
 }
 
-.osmContainer:hover .osmButtons.menu .opened,
 .openMenu .osmButtons.menu .opened {
     opacity: 1 !important;
     -webkit-transition: all .25s ease-in;
@@ -176,7 +173,6 @@
     transition-delay: 500ms;
 }
 
-.osmContainer:hover .osmButtons.item,
 .openMenu .osmButtons.item {
     opacity: 0.8;
     -webkit-transform: none;

--- a/MMM-OnScreenMenu.js
+++ b/MMM-OnScreenMenu.js
@@ -10,6 +10,7 @@
 Module.register("MMM-OnScreenMenu", {
     defaults: {
         touchMode: true,
+        openOnHover: true,
         menuName: "MAIN",
         menuItems: {
             monitorOff: { title: "Turn Off Monitor", icon: "television", source: "SERVER" },
@@ -49,7 +50,7 @@ Module.register("MMM-OnScreenMenu", {
         this._manualOpen = state;
         this.updateMenuState();
     },
-    getMenuOpen: function() { return this.getHovering() || this.getManualOpen(); },
+    getMenuOpen: function() { return (this.config.openOnHover && this.getHovering()) || this.getManualOpen(); },
     selectedMenuItem: '',
     actionTimers: {},
 

--- a/MMM-OnScreenMenu.js
+++ b/MMM-OnScreenMenu.js
@@ -307,7 +307,7 @@ Module.register("MMM-OnScreenMenu", {
         }
     },
 
-    mouseoutCB: function() {
+    mouseleaveCB: function() {
         this.setHovering(false);
         if (this.config.enableKeyBindings && !this.getMenuOpen() &&
             this.currentKeyPressMode === this.config.keyBindingsMode) {
@@ -339,7 +339,7 @@ Module.register("MMM-OnScreenMenu", {
         nav.id = "menuContainer";
         nav.className = "osmContainer";
         nav.onmouseenter = () => this.mouseenterCB();
-        nav.onmouseout = () => this.mouseoutCB();
+        nav.onmouseleave = () => this.mouseleaveCB();
 
         var fab = document.createElement("span");
         fab.className = "osmButtons menu";
@@ -371,7 +371,7 @@ Module.register("MMM-OnScreenMenu", {
 
         /* FLOATING ACTION BUTTON MENU HTML SHOULD LOOK LIKE THIS:
           <div id="menu" class="bottom_right">
-          <nav id="menuContainer" class="container" onmouseenter="mouseenterCB()" onmouseout="mouseoutCB();"> 
+          <nav id="menuContainer" class="container" onmouseenter="mouseenterCB()" onmouseleave="mouseleaveCB();"> 
             <span class="buttons item" id="monitorOff" onclick="clicked('Turn Off Display')" tooltip="Turn Off Display">
               <i class="fa fa-television" aria-hidden="true"></i></span>
             <span class="buttons item" id="restart" onclick="clicked('Restart MagicMirror')" tooltip="Restart MagicMirror">

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ var config = {
 |-----------------------|-----------
 | `menuName` | *Optional* - Set the name of the menu. Only needs to be changed if using multiple instances of the module.<br>*Default:* `"MAIN"`.
 | `touchMode` | *Optional* - Enable Touch Mode for the menu.<br>When enabled, the menu button will always be visible and all tooltips will be shown when the menu is open.<br>When disabled, the menu will only appear when hovered over, clicked, or opened with a menu key.<br>*Default:* `true`
+| `openOnHover` | *Optional* - When enabled the menu will appear when hovered over. For touch displays this should be disabled. *Default:* `true`
 | `enableKeyboard` | *Optional* - Enable basic keyboard control.<br>Menu can be controlled with the `ContextMenu` key (usually next to `Right-Alt`), Arrow Up/Down, and Enter.<br>*Default:* `true`<br><br>*To customize keys:* manually edit the `setupMousetrap` function in `MMM-OnScreenMenu.js`.
 | `enableKeyBindings` | *Optional* - Enable integration with [MMM-KeyBindings](https://github.com/shbatm/MMM-KeyBindings) for bluetooth remote and better keyboard control.  See [KeyBindings Config](#keybindings-config) below.
 | `menuItems` | See [Menu Items](#menu-items) below.


### PR DESCRIPTION
Added `openOnHover` option, which is enabled by default for backwards compatibility. When the option is disabled, the menu does not open on hover, this is useful for touchscreens, where "hovering" is only emulated. So this should finally fix #13.

The refactoring of the open/close menu javascript and css handling now make it also possible to add logic to reliable close the menu. e.g. close the menu after 5 seconds or close the menu after press of a menu item.